### PR TITLE
Add advanced usage analytics module

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -2409,6 +2409,20 @@ model ModuleUsageLog {
   timestamp  DateTime @default(now())
 }
 
+/// Enhanced usage log with richer metadata
+model UsageLog {
+  id         String   @id @default(cuid())
+  userId     String
+  role       Role
+  schoolId   String
+  module     String
+  deviceType String
+  timestamp  DateTime @default(now())
+
+  @@index([userId])
+  @@index([schoolId])
+}
+
 model OtpToken {
   id        String   @id @default(cuid())
   userId    String   @map("user_id")

--- a/backend/src/modules/usageAnalytics/usageAnalytics.controller.ts
+++ b/backend/src/modules/usageAnalytics/usageAnalytics.controller.ts
@@ -1,0 +1,30 @@
+import { Request, Response, NextFunction } from "express";
+import { getUsageAnalytics, logUsage } from "./usageAnalytics.service";
+
+export async function postUsageLog(req: Request, res: Response, next: NextFunction) {
+  try {
+    const userId = req.user?.id as string;
+    const role = req.user?.role as string;
+    const schoolId = req.user?.schoolId as string || req.body.schoolId;
+    const { module, deviceType } = req.body;
+    await logUsage({ userId, role, schoolId, module, deviceType });
+    res.json({ success: true });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function getUsage(req: Request, res: Response, next: NextFunction) {
+  try {
+    const data = await getUsageAnalytics({
+      role: req.query.role as string | undefined,
+      module: req.query.module as string | undefined,
+      device: req.query.device as string | undefined,
+      range: req.query.range as string | undefined,
+      schoolId: req.query.schoolId as string | undefined,
+    });
+    res.json(data);
+  } catch (err) {
+    next(err);
+  }
+}

--- a/backend/src/modules/usageAnalytics/usageAnalytics.routes.ts
+++ b/backend/src/modules/usageAnalytics/usageAnalytics.routes.ts
@@ -1,0 +1,17 @@
+import { Router } from "express";
+import { postUsageLog, getUsage } from "./usageAnalytics.controller";
+import { permit } from "../../utils/jwt_utils";
+import { Role } from "@prisma/client";
+
+const router = Router();
+
+router.post(
+  "/usage-analytics/log",
+  permit(Role.admin, Role.superadmin, Role.teacher, Role.student, Role.parent),
+  postUsageLog
+);
+
+router.get("/usage-analytics/admin", permit(Role.admin), getUsage);
+router.get("/usage-analytics/superadmin", permit(Role.superadmin), getUsage);
+
+export default router;

--- a/backend/src/modules/usageAnalytics/usageAnalytics.service.ts
+++ b/backend/src/modules/usageAnalytics/usageAnalytics.service.ts
@@ -1,0 +1,61 @@
+import { prisma } from "../../db/prisma";
+import { subDays } from "date-fns";
+
+export interface UsageAnalyticsQuery {
+  role?: string;
+  module?: string;
+  device?: string;
+  range?: string; // today, 7d, 30d
+  schoolId?: string;
+}
+
+export async function logUsage(data: {
+  userId: string;
+  role: string;
+  schoolId: string;
+  module: string;
+  deviceType: string;
+}) {
+  await prisma.usageLog.create({ data });
+}
+
+export async function getUsageAnalytics(query: UsageAnalyticsQuery) {
+  const where: any = {};
+  if (query.role) where.role = query.role;
+  if (query.module) where.module = query.module;
+  if (query.device) where.deviceType = query.device;
+  if (query.schoolId) where.schoolId = query.schoolId;
+
+  if (query.range) {
+    const now = new Date();
+    if (query.range === "today") {
+      where.timestamp = { gte: subDays(now, 1) };
+    } else if (query.range === "7") {
+      where.timestamp = { gte: subDays(now, 7) };
+    } else if (query.range === "30") {
+      where.timestamp = { gte: subDays(now, 30) };
+    }
+  }
+
+  const logs = await prisma.usageLog.findMany({ where });
+
+  const usageByDay: Record<string, number> = {};
+  const usageByModule: Record<string, number> = {};
+  const usageByRole: Record<string, number> = {};
+
+  logs.forEach((log) => {
+    const day = log.timestamp.toISOString().split("T")[0];
+    usageByDay[day] = (usageByDay[day] || 0) + 1;
+    usageByModule[log.module] = (usageByModule[log.module] || 0) + 1;
+    usageByRole[log.role] = (usageByRole[log.role] || 0) + 1;
+  });
+
+  const total = logs.length;
+  const result = {
+    total,
+    usageByDay,
+    usageByModule,
+    usageByRole,
+  };
+  return result;
+}

--- a/backend/src/routes/app.ts
+++ b/backend/src/routes/app.ts
@@ -82,6 +82,7 @@ import employeeRoutes from "../modules/admin/routes/dashboard/hrm/employeeRoutes
 import leaveRequestRoutes from "../modules/superadmin/routes/core/leaveRequestRoutes";
 import holidayRoutes from "../modules/admin/routes/dashboard/holidayRoutes";
 import analyticsRoutes from "../modules/analytics/analytics.routes";
+import usageAnalyticsRoutes from "../modules/usageAnalytics/usageAnalytics.routes";
 
 import feeHandlerRoutes from "./paymenthandler/feeHandlerRoutes";
 import invoiceRoutes from "./paymenthandler/invoiceRoutes";
@@ -217,6 +218,7 @@ apiRouter.use(sectionRoutes);
 apiRouter.use(studentAllRoutes);
 apiRouter.use(chatRoutes);
 apiRouter.use(analyticsRoutes);
+apiRouter.use(usageAnalyticsRoutes);
 apiRouter.use(DashboardHomeRoutes);
 
 // Test Todo

--- a/frontend/src/hooks/useUsageLogger.tsx
+++ b/frontend/src/hooks/useUsageLogger.tsx
@@ -1,0 +1,17 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router";
+import { useSelector } from "react-redux";
+import { logUsage } from "../services/analyticsService";
+
+const useUsageLogger = () => {
+  const location = useLocation();
+  const user = useSelector((state: any) => state.auth.userObj);
+
+  useEffect(() => {
+    if (!user) return;
+    const deviceType = /Mobi/i.test(navigator.userAgent) ? "Mobile" : "Desktop";
+    logUsage({ module: location.pathname, deviceType }).catch(() => {});
+  }, [location.pathname, user]);
+};
+
+export default useUsageLogger;

--- a/frontend/src/pages/Admin/UsageAnalytics.tsx
+++ b/frontend/src/pages/Admin/UsageAnalytics.tsx
@@ -1,18 +1,11 @@
 import { useEffect, useState } from "react";
 import ReactApexChart from "react-apexcharts";
-import { fetchUsageAnalytics } from "../../services/analyticsService";
+import { fetchAdminUsageAnalytics, UsageParams } from "../../services/analyticsService";
 import { all_routes } from "../../router/all_routes";
 import { Link } from "react-router-dom";
 
-interface GraphPoint {
-  date: string;
-  staff: number;
-  student: number;
-  parent: number;
-}
-
 const UsageAnalytics = () => {
-  const [role, setRole] = useState("");
+  const [filters, setFilters] = useState<UsageParams>({});
   const [data, setData] = useState<any>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -20,7 +13,7 @@ const UsageAnalytics = () => {
   const loadData = async () => {
     setLoading(true);
     try {
-      const res = await fetchUsageAnalytics({ role: role || undefined });
+      const res = await fetchAdminUsageAnalytics(filters);
       setData(res.data);
     } catch (e:any) {
       setError(e.message);
@@ -29,29 +22,26 @@ const UsageAnalytics = () => {
     }
   };
 
-  useEffect(() => { loadData(); }, [role]);
-
+  useEffect(() => { loadData(); }, [filters]);
   const roleOptions = ["", "staff", "student", "parent"];
+  const deviceOptions = ["", "Mobile", "Desktop"];
+  const rangeOptions = [
+    { value: "today", label: "Today" },
+    { value: "7", label: "7 Days" },
+    { value: "30", label: "30 Days" },
+  ];
 
   if (loading) return <div className="page-wrapper"><div className="content">Loading...</div></div>;
   if (error) return <div className="page-wrapper"><div className="content">Error: {error}</div></div>;
   if (!data) return <div className="page-wrapper"><div className="content">No data</div></div>;
 
+  const lineCategories = Object.keys(data.usageByDay);
   const lineSeries = [
     {
-      name: "Staff",
-      data: (data.loginFrequencyGraph as GraphPoint[]).map(p => p.staff)
-    },
-    {
-      name: "Students",
-      data: (data.loginFrequencyGraph as GraphPoint[]).map(p => p.student)
-    },
-    {
-      name: "Parents",
-      data: (data.loginFrequencyGraph as GraphPoint[]).map(p => p.parent)
+      name: "Usage",
+      data: Object.values(data.usageByDay)
     }
   ];
-  const lineCategories = (data.loginFrequencyGraph as GraphPoint[]).map(p => p.date);
 
   return (
     <div className="page-wrapper">
@@ -60,16 +50,60 @@ const UsageAnalytics = () => {
           <h4 className="page-title">Usage Analytics</h4>
           <Link className="btn btn-primary" to={all_routes.adminDashboard}>Dashboard</Link>
         </div>
-        <div className="mb-3">
-          <select className="form-select w-auto" value={role} onChange={e => setRole(e.target.value)}>
-            {roleOptions.map(r => <option key={r} value={r}>{r || "All Roles"}</option>)}
+        <div className="mb-3 d-flex flex-wrap gap-2">
+          <select
+            className="form-select w-auto"
+            value={filters.role || ""}
+            onChange={(e) => setFilters({ ...filters, role: e.target.value || undefined })}
+          >
+            {roleOptions.map((r) => (
+              <option key={r} value={r}>
+                {r || "All Roles"}
+              </option>
+            ))}
           </select>
+          <select
+            className="form-select w-auto"
+            value={filters.device || ""}
+            onChange={(e) => setFilters({ ...filters, device: e.target.value || undefined })}
+          >
+            {deviceOptions.map((r) => (
+              <option key={r} value={r}>
+                {r || "All Devices"}
+              </option>
+            ))}
+          </select>
+          <select
+            className="form-select w-auto"
+            value={filters.range || ""}
+            onChange={(e) => setFilters({ ...filters, range: e.target.value || undefined })}
+          >
+            {rangeOptions.map((r) => (
+              <option key={r.value} value={r.value}>
+                {r.label}
+              </option>
+            ))}
+          </select>
+          <input
+            type="text"
+            className="form-control w-auto"
+            placeholder="Module"
+            value={filters.module || ""}
+            onChange={(e) => setFilters({ ...filters, module: e.target.value || undefined })}
+          />
         </div>
         <div className="row">
-          <div className="col-md-12">
+          <div className="col-md-6">
             <div className="card mb-4">
               <div className="card-body">
                 <ReactApexChart type="line" height={300} series={lineSeries} options={{ xaxis:{ categories: lineCategories } }} />
+              </div>
+            </div>
+          </div>
+          <div className="col-md-6">
+            <div className="card mb-4">
+              <div className="card-body">
+                <ReactApexChart type="bar" height={300} series={[{data: Object.values(data.usageByModule)}]} options={{ xaxis:{ categories: Object.keys(data.usageByModule) } }} />
               </div>
             </div>
           </div>

--- a/frontend/src/pages/SuperAdmin/UsageAnalytics.tsx
+++ b/frontend/src/pages/SuperAdmin/UsageAnalytics.tsx
@@ -1,18 +1,12 @@
 import { useEffect, useState } from "react";
 import ReactApexChart from "react-apexcharts";
-import { fetchUsageAnalytics } from "../../services/analyticsService";
+import { fetchSuperAdminUsageAnalytics, UsageParams } from "../../services/analyticsService";
 import { all_routes } from "../../router/all_routes";
 import { Link } from "react-router-dom";
 
-interface GraphPoint {
-  date: string;
-  staff: number;
-  student: number;
-  parent: number;
-}
 
 const UsageAnalytics = () => {
-  const [role, setRole] = useState("");
+  const [filters, setFilters] = useState<UsageParams>({});
   const [data, setData] = useState<any>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -20,7 +14,7 @@ const UsageAnalytics = () => {
   const loadData = async () => {
     setLoading(true);
     try {
-      const res = await fetchUsageAnalytics({ role: role || undefined });
+      const res = await fetchSuperAdminUsageAnalytics(filters);
       setData(res.data);
     } catch (e:any) {
       setError(e.message);
@@ -29,18 +23,21 @@ const UsageAnalytics = () => {
     }
   };
 
-  useEffect(() => { loadData(); }, [role]);
-
+  useEffect(() => { loadData(); }, [filters]);
   const roleOptions = ["", "staff", "student", "parent"];
+  const deviceOptions = ["", "Mobile", "Desktop"];
+  const rangeOptions = [
+    { value: "today", label: "Today" },
+    { value: "7", label: "7 Days" },
+    { value: "30", label: "30 Days" },
+  ];
 
   if (loading) return <div className="page-wrapper"><div className="content">Loading...</div></div>;
   if (error) return <div className="page-wrapper"><div className="content">Error: {error}</div></div>;
   if (!data) return <div className="page-wrapper"><div className="content">No data</div></div>;
 
-  const barSeries = [{
-    data: data.topModulesUsed.map((m: any) => m.hits)
-  }];
-  const barCategories = data.topModulesUsed.map((m: any) => m.module);
+  const barSeries = [{ data: Object.values(data.usageByModule) }];
+  const barCategories = Object.keys(data.usageByModule);
 
   return (
     <div className="page-wrapper">
@@ -49,10 +46,54 @@ const UsageAnalytics = () => {
           <h4 className="page-title">Usage Analytics</h4>
           <Link className="btn btn-primary" to={all_routes.superAdminDashboard}>Dashboard</Link>
         </div>
-        <div className="mb-3">
-          <select className="form-select w-auto" value={role} onChange={e => setRole(e.target.value)}>
-            {roleOptions.map(r => <option key={r} value={r}>{r || "All Roles"}</option>)}
+        <div className="mb-3 d-flex flex-wrap gap-2">
+          <select
+            className="form-select w-auto"
+            value={filters.role || ""}
+            onChange={(e) => setFilters({ ...filters, role: e.target.value || undefined })}
+          >
+            {roleOptions.map((r) => (
+              <option key={r} value={r}>
+                {r || "All Roles"}
+              </option>
+            ))}
           </select>
+          <select
+            className="form-select w-auto"
+            value={filters.device || ""}
+            onChange={(e) => setFilters({ ...filters, device: e.target.value || undefined })}
+          >
+            {deviceOptions.map((r) => (
+              <option key={r} value={r}>
+                {r || "All Devices"}
+              </option>
+            ))}
+          </select>
+          <select
+            className="form-select w-auto"
+            value={filters.range || ""}
+            onChange={(e) => setFilters({ ...filters, range: e.target.value || undefined })}
+          >
+            {rangeOptions.map((r) => (
+              <option key={r.value} value={r.value}>
+                {r.label}
+              </option>
+            ))}
+          </select>
+          <input
+            type="text"
+            className="form-control w-auto"
+            placeholder="Module"
+            value={filters.module || ""}
+            onChange={(e) => setFilters({ ...filters, module: e.target.value || undefined })}
+          />
+          <input
+            type="text"
+            className="form-control w-auto"
+            placeholder="School ID"
+            value={filters.schoolId || ""}
+            onChange={(e) => setFilters({ ...filters, schoolId: e.target.value || undefined })}
+          />
         </div>
         <div className="row">
           <div className="col-md-12">

--- a/frontend/src/services/analyticsService.ts
+++ b/frontend/src/services/analyticsService.ts
@@ -1,13 +1,39 @@
 import { AxiosResponse } from "axios";
 import BaseApi from "./BaseApi";
 
-export const fetchUsageAnalytics = async (
-  params: { role?: string; classId?: string; branchId?: string } = {}
+export interface UsageParams {
+  role?: string;
+  module?: string;
+  device?: string;
+  range?: string;
+  schoolId?: string;
+}
+export const fetchAdminUsageAnalytics = async (
+  params: UsageParams = {}
 ): Promise<AxiosResponse<any>> => {
   const search = new URLSearchParams();
-  if (params.role) search.append("role", params.role);
-  if (params.classId) search.append("classId", params.classId);
-  if (params.branchId) search.append("branchId", params.branchId);
+  Object.entries(params).forEach(([k, v]) => {
+    if (v) search.append(k, v);
+  });
   const query = search.toString();
-  return BaseApi.getRequest(`/analytics/usage${query ? `?${query}` : ""}`);
+  return BaseApi.getRequest(`/usage-analytics/admin${query ? `?${query}` : ""}`);
+};
+
+export const fetchSuperAdminUsageAnalytics = async (
+  params: UsageParams = {}
+): Promise<AxiosResponse<any>> => {
+  const search = new URLSearchParams();
+  Object.entries(params).forEach(([k, v]) => {
+    if (v) search.append(k, v);
+  });
+  const query = search.toString();
+  return BaseApi.getRequest(`/usage-analytics/superadmin${query ? `?${query}` : ""}`);
+};
+
+export const logUsage = async (data: {
+  module: string;
+  deviceType: string;
+  schoolId?: string;
+}): Promise<AxiosResponse<any>> => {
+  return BaseApi.postRequest(`/usage-analytics/log`, data);
 };

--- a/frontend/src/wrapper/CommonRouteWrapper.tsx
+++ b/frontend/src/wrapper/CommonRouteWrapper.tsx
@@ -7,6 +7,7 @@ import { getUserProfile } from "../services/authService";
 import { all_routes } from "../router/all_routes";
 import AppConfig from "../config/config";
 import CustomLoader from "../components/Loader";
+import useUsageLogger from "../hooks/useUsageLogger";
 
 const CommonRouteWrapper = () => {
   const dispatch = useDispatch();
@@ -14,6 +15,8 @@ const CommonRouteWrapper = () => {
   const location = useLocation();
   const isLoggedIn = useSelector((state: any) => state.auth.isLoggedIn);
   const triggerPostLogin = useSelector((state: any) => state.auth.triggerPostLogin);
+
+  useUsageLogger();
 
   const [showLoader, setShowLoader] = useState<boolean>(true);
   const [accessToken, setAccessToken] = useState<string>("");


### PR DESCRIPTION
## Summary
- model `UsageLog` to store rich usage data
- API routes for logging and retrieving analytics
- client hook for automatic logging on route change
- improved usage analytics pages with filters and charts

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871f07b94d08323b8c75217c40ab776