### PR TITLE
Fix usage analytics for superadmin

### DIFF
--- a/backend/prisma/migrations/20250712072000_add_usage_log_table/migration.sql
+++ b/backend/prisma/migrations/20250712072000_add_usage_log_table/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "UsageLog" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "role" "Role" NOT NULL,
+    "schoolId" TEXT,
+    "module" TEXT NOT NULL,
+    "deviceType" TEXT NOT NULL,
+    "timestamp" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "UsageLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "UsageLog_userId_idx" ON "UsageLog"("userId");
+
+-- CreateIndex
+CREATE INDEX "UsageLog_schoolId_idx" ON "UsageLog"("schoolId");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -2414,7 +2414,7 @@ model UsageLog {
   id         String   @id @default(cuid())
   userId     String
   role       Role
-  schoolId   String
+  schoolId   String?
   module     String
   deviceType String
   timestamp  DateTime @default(now())

--- a/backend/src/modules/usageAnalytics/usageAnalytics.controller.ts
+++ b/backend/src/modules/usageAnalytics/usageAnalytics.controller.ts
@@ -5,7 +5,7 @@ export async function postUsageLog(req: Request, res: Response, next: NextFuncti
   try {
     const userId = req.user?.id as string;
     const role = req.user?.role as string;
-    const schoolId = req.user?.schoolId as string || req.body.schoolId;
+    const schoolId = (req.user?.schoolId as string | undefined) || req.body.schoolId;
     const { module, deviceType } = req.body;
     await logUsage({ userId, role, schoolId, module, deviceType });
     res.json({ success: true });

--- a/backend/src/modules/usageAnalytics/usageAnalytics.service.ts
+++ b/backend/src/modules/usageAnalytics/usageAnalytics.service.ts
@@ -14,7 +14,7 @@ import type { Role } from "@prisma/client";
 export async function logUsage(data: {
   userId: string;
   role: string;
-  schoolId: string;
+  schoolId?: string;
   module: string;
   deviceType: string;
 }) {

--- a/frontend/src/hooks/useUsageLogger.tsx
+++ b/frontend/src/hooks/useUsageLogger.tsx
@@ -10,7 +10,8 @@ const useUsageLogger = () => {
   useEffect(() => {
     if (!user) return;
     const deviceType = /Mobi/i.test(navigator.userAgent) ? "Mobile" : "Desktop";
-    logUsage({ module: location.pathname, deviceType }).catch(() => {});
+    const schoolId = user.schoolId || localStorage.getItem("schoolId") || undefined;
+    logUsage({ module: location.pathname, deviceType, schoolId }).catch(() => {});
   }, [location.pathname, user]);
 };
 


### PR DESCRIPTION
## Summary
- allow optional `schoolId` in usage log schema
- add migration for `UsageLog` table
- adjust usage logging controller and service
- include school id when logging from the frontend

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68720bd2bedc832399f28ff1673d4cec