### PR TITLE
Add usage analytics endpoints

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -2413,10 +2413,13 @@ model ModuleUsageLog {
 model UsageLog {
   id         String   @id @default(cuid())
   userId     String
-  role       Role
-  schoolId   String?
+  schoolId   String
   module     String
+  role       Role
   deviceType String
+  duration   Int?
+  lat        Float?
+  lng        Float?
   timestamp  DateTime @default(now())
 
   @@index([userId])

--- a/backend/src/modules/usageAnalytics/usageAnalytics.controller.ts
+++ b/backend/src/modules/usageAnalytics/usageAnalytics.controller.ts
@@ -1,13 +1,18 @@
 import { Request, Response, NextFunction } from "express";
-import { getUsageAnalytics, logUsage } from "./usageAnalytics.service";
+import {
+  getUsageAnalytics,
+  logUsage,
+  listRoles,
+  getSchoolsWithModules,
+} from "./usageAnalytics.service";
 
 export async function postUsageLog(req: Request, res: Response, next: NextFunction) {
   try {
     const userId = req.user?.id as string;
     const role = req.user?.role as string;
     const schoolId = (req.user?.schoolId as string | undefined) || req.body.schoolId;
-    const { module, deviceType } = req.body;
-    await logUsage({ userId, role, schoolId, module, deviceType });
+    const { module, deviceType, duration, lat, lng } = req.body;
+    await logUsage({ userId, role, schoolId, module, deviceType, duration, lat, lng });
     res.json({ success: true });
   } catch (err) {
     next(err);
@@ -16,13 +21,31 @@ export async function postUsageLog(req: Request, res: Response, next: NextFuncti
 
 export async function getUsage(req: Request, res: Response, next: NextFunction) {
   try {
+    let schoolId = req.query.schoolId as string | undefined;
+    if (req.user?.role !== "superadmin") {
+      schoolId = req.user?.schoolId as string | undefined;
+    }
     const data = await getUsageAnalytics({
       role: req.query.role as string | undefined,
       module: req.query.module as string | undefined,
       device: req.query.device as string | undefined,
       range: req.query.range as string | undefined,
-      schoolId: req.query.schoolId as string | undefined,
+      schoolId,
+      latlng: req.query.latlng as string | undefined,
     });
+    res.json(data);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export function getRoles(req: Request, res: Response) {
+  res.json(listRoles());
+}
+
+export async function getSchoolsModules(req: Request, res: Response, next: NextFunction) {
+  try {
+    const data = await getSchoolsWithModules();
     res.json(data);
   } catch (err) {
     next(err);

--- a/backend/src/modules/usageAnalytics/usageAnalytics.routes.ts
+++ b/backend/src/modules/usageAnalytics/usageAnalytics.routes.ts
@@ -1,17 +1,32 @@
 import { Router } from "express";
-import { postUsageLog, getUsage } from "./usageAnalytics.controller";
+import {
+  postUsageLog,
+  getUsage,
+  getRoles,
+  getSchoolsModules,
+} from "./usageAnalytics.controller";
 import { permit } from "../../utils/jwt_utils";
 import { Role } from "@prisma/client";
 
 const router = Router();
 
 router.post(
-  "/usage-analytics/log",
-  permit(Role.admin, Role.superadmin, Role.teacher, Role.student, Role.parent),
+  "/usage-log",
+  permit(
+    Role.admin,
+    Role.superadmin,
+    Role.teacher,
+    Role.student,
+    Role.parent,
+    Role.transport,
+    Role.account,
+    Role.employee
+  ),
   postUsageLog
 );
 
-router.get("/usage-analytics/admin", permit(Role.admin), getUsage);
-router.get("/usage-analytics/superadmin", permit(Role.superadmin), getUsage);
+router.get("/usage-analytics", permit(Role.admin, Role.superadmin), getUsage);
+router.get("/roles", getRoles);
+router.get("/schools-with-modules", permit(Role.superadmin), getSchoolsModules);
 
 export default router;

--- a/backend/src/modules/usageAnalytics/usageAnalytics.service.ts
+++ b/backend/src/modules/usageAnalytics/usageAnalytics.service.ts
@@ -7,21 +7,64 @@ export interface UsageAnalyticsQuery {
   device?: string;
   range?: string; // today, 7d, 30d
   schoolId?: string;
+  latlng?: string;
 }
 
 import type { Role } from "@prisma/client";
 
+export function listRoles() {
+  return [
+    "admin",
+    "teacher",
+    "student",
+    "parent",
+    "transport",
+    "account",
+    "employee",
+  ];
+}
+
+export async function getSchoolsWithModules() {
+  const schools = await prisma.school.findMany({
+    include: {
+      user: {
+        select: {
+          userPermissions: {
+            where: { status: 1 },
+            select: { moduleName: true },
+          },
+        },
+      },
+    },
+  });
+
+  return schools.map((s) => ({
+    id: s.id,
+    schoolName: s.schoolName,
+    modules: s.user?.userPermissions.map((p) => p.moduleName) || [],
+  }));
+}
+
 export async function logUsage(data: {
   userId: string;
   role: string;
-  schoolId?: string;
+  schoolId: string;
   module: string;
   deviceType: string;
+  duration?: number;
+  lat?: number;
+  lng?: number;
 }) {
   await prisma.usageLog.create({
     data: {
-      ...data,
+      userId: data.userId,
       role: data.role as Role,
+      schoolId: data.schoolId,
+      module: data.module,
+      deviceType: data.deviceType,
+      duration: data.duration,
+      lat: data.lat,
+      lng: data.lng,
     },
   });
 }
@@ -32,6 +75,13 @@ export async function getUsageAnalytics(query: UsageAnalyticsQuery) {
   if (query.module) where.module = query.module;
   if (query.device) where.deviceType = query.device;
   if (query.schoolId) where.schoolId = query.schoolId;
+  if (query.latlng) {
+    const parts = query.latlng.split(',').map((p) => parseFloat(p));
+    if (parts.length === 2 && !isNaN(parts[0]) && !isNaN(parts[1])) {
+      where.lat = parts[0];
+      where.lng = parts[1];
+    }
+  }
 
   if (query.range) {
     const now = new Date();
@@ -66,5 +116,3 @@ export async function getUsageAnalytics(query: UsageAnalyticsQuery) {
   };
   return result;
 }
-
-// test function to log usage


### PR DESCRIPTION
## Summary
- update usage log model for extra metadata
- expand analytics service with role list and schools with modules
- allow duration and location in usage log
- add admin/superadmin usage analytics endpoint
- expose roles and schools-with-modules routes

## Testing
- `npm test` *(fails: jest not found)*
- `npx prisma generate` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68728992c62883238ea2021ea7f29f33