### PR TITLE
Fix usage analytics routes

### DIFF
--- a/backend/src/modules/usageAnalytics/usageAnalytics.routes.ts
+++ b/backend/src/modules/usageAnalytics/usageAnalytics.routes.ts
@@ -10,6 +10,7 @@ import { Role } from "@prisma/client";
 
 const router = Router();
 
+// Existing backward compatible endpoint
 router.post(
   "/usage-log",
   permit(
@@ -25,7 +26,28 @@ router.post(
   postUsageLog
 );
 
+// New endpoint aligning with frontend service path
+router.post(
+  "/usage-analytics/log",
+  permit(
+    Role.admin,
+    Role.superadmin,
+    Role.teacher,
+    Role.student,
+    Role.parent,
+    Role.transport,
+    Role.account,
+    Role.employee
+  ),
+  postUsageLog
+);
+
+// Shared analytics endpoint for both admin and superadmin
 router.get("/usage-analytics", permit(Role.admin, Role.superadmin), getUsage);
+
+// Explicit endpoints used by the frontend
+router.get("/usage-analytics/admin", permit(Role.admin), getUsage);
+router.get("/usage-analytics/superadmin", permit(Role.superadmin), getUsage);
 router.get("/roles", getRoles);
 router.get("/schools-with-modules", permit(Role.superadmin), getSchoolsModules);
 


### PR DESCRIPTION
## Summary
- add new endpoints for usage analytics

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872979bd68083238e136388f99c8828