### PR TITLE
Add teacher student leave request endpoint

### DIFF
--- a/backend/src/modules/teacher/controllers/dashboard/leaveRequestController.ts
+++ b/backend/src/modules/teacher/controllers/dashboard/leaveRequestController.ts
@@ -1,0 +1,53 @@
+import { Request, Response } from "express";
+import { prisma } from "../../../../db/prisma";
+
+// Get leave requests of students belonging to classes assigned to a teacher
+export const getTeacherStudentsLeaveRequests = async (
+  req: Request,
+  res: Response
+): Promise<any> => {
+  try {
+    const { teacherId } = req.params;
+
+    if (!teacherId) {
+      return res.status(400).json({ error: "teacherId is required" });
+    }
+
+    const classes = await prisma.class.findMany({
+      where: {
+        Teacher: {
+          some: { id: teacherId },
+        },
+      },
+      select: { id: true },
+    });
+
+    const classIds = classes.map((c) => c.id);
+
+    if (classIds.length === 0) {
+      return res.status(404).json({ error: "No classes found for this teacher" });
+    }
+
+    const students = await prisma.student.findMany({
+      where: { classId: { in: classIds } },
+      select: { userId: true },
+    });
+
+    const userIds = students.map((s) => s.userId);
+
+    if (userIds.length === 0) {
+      return res.status(200).json([]);
+    }
+
+    const leaves = await prisma.leaveRequest.findMany({
+      where: { userId: { in: userIds } },
+      include: { user: { select: { id: true, name: true } } },
+      orderBy: { createdAt: "desc" },
+    });
+
+    return res.status(200).json(leaves);
+  } catch (error) {
+    console.error("Error fetching leave requests:", error);
+    return res.status(500).json({ error: (error as any).message });
+  }
+};

--- a/backend/src/modules/teacher/routes/dashboard/leaveRequestRoutes.ts
+++ b/backend/src/modules/teacher/routes/dashboard/leaveRequestRoutes.ts
@@ -1,0 +1,8 @@
+import express from 'express';
+import { getTeacherStudentsLeaveRequests } from '../../controllers/dashboard/leaveRequestController';
+
+const router = express.Router();
+
+router.get('/teacher/:teacherId/student-leave-requests', getTeacherStudentsLeaveRequests);
+
+export default router;

--- a/backend/src/routes/app.ts
+++ b/backend/src/routes/app.ts
@@ -77,6 +77,7 @@ import { Role } from "@prisma/client";
 import userRoutes from "../modules/superadmin/routes/core/userRoutes";
 import contactMessageRoutes from "../modules/superadmin/routes/core/contactMessageRoutes";
 import homeWorkRoutes from "../modules/teacher/routes/dashboard/homeWorkRoutes";
+import teacherLeaveRequestRoutes from "../modules/teacher/routes/dashboard/leaveRequestRoutes";
 import addStaffRoutes from "../modules/admin/routes/dashboard/hrm/addStaffRoutes";
 import employeeRoutes from "../modules/admin/routes/dashboard/hrm/employeeRoutes";
 import leaveRequestRoutes from "../modules/superadmin/routes/core/leaveRequestRoutes";
@@ -193,6 +194,7 @@ apiRouter.use(dutiesRoutes);
 apiRouter.use(payrollRoutes);
 
 apiRouter.use(homeWorkRoutes);
+apiRouter.use(teacherLeaveRequestRoutes);
 apiRouter.use(addStaffRoutes);
 apiRouter.use(employeeRoutes);
 apiRouter.use(leaveRequestRoutes);

--- a/backend/tests/controller/teacher/dashboard/leaveRequestController.test.ts
+++ b/backend/tests/controller/teacher/dashboard/leaveRequestController.test.ts
@@ -1,0 +1,39 @@
+import request from 'supertest';
+import express from 'express';
+import routes from '../../../../src/modules/teacher/routes/dashboard/leaveRequestRoutes';
+import { prisma } from '../../../../src/db/prisma';
+
+jest.mock('../../../../src/db/prisma', () => {
+  const classModel = { findMany: jest.fn() };
+  const studentModel = { findMany: jest.fn() };
+  const leaveRequest = { findMany: jest.fn() };
+  return { prisma: { class: classModel, student: studentModel, leaveRequest } };
+});
+
+const app = express();
+app.use(express.json());
+app.use('/', routes);
+
+afterAll(() => {
+  jest.resetAllMocks();
+});
+
+describe('Teacher student leave requests route', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('gets leave requests', async () => {
+    (prisma.class.findMany as jest.Mock).mockResolvedValue([{ id: 'c1' }]);
+    (prisma.student.findMany as jest.Mock).mockResolvedValue([{ userId: 'u1' }]);
+    (prisma.leaveRequest.findMany as jest.Mock).mockResolvedValue([{ id: 'l1' }]);
+
+    const res = await request(app).get('/teacher/t1/student-leave-requests');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([{ id: 'l1' }]);
+  });
+
+  it('handles errors', async () => {
+    (prisma.class.findMany as jest.Mock).mockRejectedValue(new Error('fail'));
+    const res = await request(app).get('/teacher/t1/student-leave-requests');
+    expect(res.status).toBe(500);
+  });
+});


### PR DESCRIPTION
## Summary
- allow teachers to fetch leave requests from students in their classes
- wire new endpoint into API router
- add tests covering the new route

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687333111d988323b2e5eab6413a3fa3