### PR TITLE
Improve usage analytics filters

### DIFF
--- a/frontend/src/pages/SuperAdmin/UsageAnalytics.tsx
+++ b/frontend/src/pages/SuperAdmin/UsageAnalytics.tsx
@@ -1,30 +1,47 @@
 import { useEffect, useState } from "react";
 import ReactApexChart from "react-apexcharts";
-import { fetchSuperAdminUsageAnalytics, UsageParams } from "../../services/analyticsService";
+import {
+  fetchSuperAdminUsageAnalytics,
+  fetchRoles,
+  fetchSchoolsWithModules,
+  SchoolWithModules,
+  UsageParams,
+} from "../../services/analyticsService";
 import { all_routes } from "../../router/all_routes";
 import { Link } from "react-router-dom";
-
 
 const UsageAnalytics = () => {
   const [filters, setFilters] = useState<UsageParams>({});
   const [data, setData] = useState<any>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [roles, setRoles] = useState<string[]>([]);
+  const [schools, setSchools] = useState<SchoolWithModules[]>([]);
+  const [modules, setModules] = useState<string[]>([]);
 
   const loadData = async () => {
     setLoading(true);
     try {
       const res = await fetchSuperAdminUsageAnalytics(filters);
       setData(res.data);
-    } catch (e:any) {
+    } catch (e: any) {
       setError(e.message);
     } finally {
       setLoading(false);
     }
   };
 
-  useEffect(() => { loadData(); }, [filters]);
-  const roleOptions = ["", "staff", "student", "parent"];
+  useEffect(() => {
+    loadData();
+  }, [filters]);
+  useEffect(() => {
+    fetchRoles()
+      .then((res) => setRoles(["", ...res.data]))
+      .catch(() => setRoles([""]));
+    fetchSchoolsWithModules()
+      .then((res) => setSchools(res.data))
+      .catch(() => setSchools([]));
+  }, []);
   const deviceOptions = ["", "Mobile", "Desktop"];
   const rangeOptions = [
     { value: "today", label: "Today" },
@@ -32,27 +49,48 @@ const UsageAnalytics = () => {
     { value: "30", label: "30 Days" },
   ];
 
-  if (loading) return <div className="page-wrapper"><div className="content">Loading...</div></div>;
-  if (error) return <div className="page-wrapper"><div className="content">Error: {error}</div></div>;
-  if (!data) return <div className="page-wrapper"><div className="content">No data</div></div>;
+  if (loading)
+    return (
+      <div className="page-wrapper">
+        <div className="content">Loading...</div>
+      </div>
+    );
+  if (error)
+    return (
+      <div className="page-wrapper">
+        <div className="content">Error: {error}</div>
+      </div>
+    );
+  if (!data)
+    return (
+      <div className="page-wrapper">
+        <div className="content">No data</div>
+      </div>
+    );
 
   const barSeries = [{ data: Object.values(data.usageByModule) }];
   const barCategories = Object.keys(data.usageByModule);
+  const durationSeries = [{ data: Object.values(data.durationByModule || {}) }];
+  const durationCategories = Object.keys(data.durationByModule || {});
 
   return (
     <div className="page-wrapper">
       <div className="content">
         <div className="mb-3 d-flex justify-content-between align-items-center">
           <h4 className="page-title">Usage Analytics</h4>
-          <Link className="btn btn-primary" to={all_routes.superAdminDashboard}>Dashboard</Link>
+          <Link className="btn btn-primary" to={all_routes.superAdminDashboard}>
+            Dashboard
+          </Link>
         </div>
         <div className="mb-3 d-flex flex-wrap gap-2">
           <select
             className="form-select w-auto"
             value={filters.role || ""}
-            onChange={(e) => setFilters({ ...filters, role: e.target.value || undefined })}
+            onChange={(e) =>
+              setFilters({ ...filters, role: e.target.value || undefined })
+            }
           >
-            {roleOptions.map((r) => (
+            {roles.map((r) => (
               <option key={r} value={r}>
                 {r || "All Roles"}
               </option>
@@ -61,7 +99,9 @@ const UsageAnalytics = () => {
           <select
             className="form-select w-auto"
             value={filters.device || ""}
-            onChange={(e) => setFilters({ ...filters, device: e.target.value || undefined })}
+            onChange={(e) =>
+              setFilters({ ...filters, device: e.target.value || undefined })
+            }
           >
             {deviceOptions.map((r) => (
               <option key={r} value={r}>
@@ -72,7 +112,9 @@ const UsageAnalytics = () => {
           <select
             className="form-select w-auto"
             value={filters.range || ""}
-            onChange={(e) => setFilters({ ...filters, range: e.target.value || undefined })}
+            onChange={(e) =>
+              setFilters({ ...filters, range: e.target.value || undefined })
+            }
           >
             {rangeOptions.map((r) => (
               <option key={r.value} value={r.value}>
@@ -80,26 +122,60 @@ const UsageAnalytics = () => {
               </option>
             ))}
           </select>
-          <input
-            type="text"
-            className="form-control w-auto"
-            placeholder="Module"
+          <select
+            className="form-select w-auto"
             value={filters.module || ""}
-            onChange={(e) => setFilters({ ...filters, module: e.target.value || undefined })}
-          />
-          <input
-            type="text"
-            className="form-control w-auto"
-            placeholder="School ID"
+            onChange={(e) =>
+              setFilters({ ...filters, module: e.target.value || undefined })
+            }
+          >
+            <option value="">All Modules</option>
+            {modules.map((m) => (
+              <option key={m} value={m}>
+                {m}
+              </option>
+            ))}
+          </select>
+          <select
+            className="form-select w-auto"
             value={filters.schoolId || ""}
-            onChange={(e) => setFilters({ ...filters, schoolId: e.target.value || undefined })}
-          />
+            onChange={(e) => {
+              const id = e.target.value || undefined;
+              setFilters({ ...filters, schoolId: id });
+              const school = schools.find((s) => s.id === id);
+              setModules(school ? school.modules : []);
+            }}
+          >
+            <option value="">All Schools</option>
+            {schools.map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.schoolName}
+              </option>
+            ))}
+          </select>
         </div>
         <div className="row">
-          <div className="col-md-12">
+          <div className="col-md-6">
             <div className="card mb-4">
               <div className="card-body">
-                <ReactApexChart type="bar" height={300} series={barSeries} options={{ xaxis:{ categories: barCategories } }} />
+                <ReactApexChart
+                  type="bar"
+                  height={300}
+                  series={barSeries}
+                  options={{ xaxis: { categories: barCategories } }}
+                />
+              </div>
+            </div>
+          </div>
+          <div className="col-md-6">
+            <div className="card mb-4">
+              <div className="card-body">
+                <ReactApexChart
+                  type="bar"
+                  height={300}
+                  series={durationSeries}
+                  options={{ xaxis: { categories: durationCategories } }}
+                />
               </div>
             </div>
           </div>

--- a/frontend/src/services/analyticsService.ts
+++ b/frontend/src/services/analyticsService.ts
@@ -9,25 +9,29 @@ export interface UsageParams {
   schoolId?: string;
 }
 export const fetchAdminUsageAnalytics = async (
-  params: UsageParams = {}
+  params: UsageParams = {},
 ): Promise<AxiosResponse<any>> => {
   const search = new URLSearchParams();
   Object.entries(params).forEach(([k, v]) => {
     if (v) search.append(k, v);
   });
   const query = search.toString();
-  return BaseApi.getRequest(`/usage-analytics/admin${query ? `?${query}` : ""}`);
+  return BaseApi.getRequest(
+    `/usage-analytics/admin${query ? `?${query}` : ""}`,
+  );
 };
 
 export const fetchSuperAdminUsageAnalytics = async (
-  params: UsageParams = {}
+  params: UsageParams = {},
 ): Promise<AxiosResponse<any>> => {
   const search = new URLSearchParams();
   Object.entries(params).forEach(([k, v]) => {
     if (v) search.append(k, v);
   });
   const query = search.toString();
-  return BaseApi.getRequest(`/usage-analytics/superadmin${query ? `?${query}` : ""}`);
+  return BaseApi.getRequest(
+    `/usage-analytics/superadmin${query ? `?${query}` : ""}`,
+  );
 };
 
 export const logUsage = async (data: {
@@ -36,4 +40,20 @@ export const logUsage = async (data: {
   schoolId?: string;
 }): Promise<AxiosResponse<any>> => {
   return BaseApi.postRequest(`/usage-analytics/log`, data);
+};
+
+export const fetchRoles = async (): Promise<AxiosResponse<string[]>> => {
+  return BaseApi.getRequest(`/roles`);
+};
+
+export interface SchoolWithModules {
+  id: string;
+  schoolName: string;
+  modules: string[];
+}
+
+export const fetchSchoolsWithModules = async (): Promise<
+  AxiosResponse<SchoolWithModules[]>
+> => {
+  return BaseApi.getRequest(`/schools-with-modules`);
 };


### PR DESCRIPTION
## Summary
- expose duration and location details in usage analytics service
- expose roles and school/module lookup on the frontend
- allow selecting schools, modules, and roles dynamically for super admin
- support dynamic role list and show time-per-module on admin analytics

## Testing
- `npm test` *(fails: jest not found)*
- `npm run tsc` *(fails: cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_68729afeeb0c8323b80d9f746c4228f1