### PR TITLE
Return user names for answers

### DIFF
--- a/backend/src/modules/admin/controllers/dashboard/answerController.ts
+++ b/backend/src/modules/admin/controllers/dashboard/answerController.ts
@@ -38,10 +38,11 @@ export const getAnswersByDoubtId = async (req: Request, res: Response, next:Next
     try {
       const answers = await prisma.answer.findMany({
         where: { doubtId },
+        include: { user: { select: { name: true } } },
       });
       res.status(200).json(answers);
     } catch (error) {
-          next(handlePrismaError(error));
+      next(handlePrismaError(error));
     }
   };
   

--- a/backend/tests/controller/admin/dashboard/answerController.test.ts
+++ b/backend/tests/controller/admin/dashboard/answerController.test.ts
@@ -18,10 +18,12 @@ describe('Answer routes', () => {
   beforeEach(() => jest.clearAllMocks());
 
   it('returns answers list', async () => {
-    (prisma.answer.findMany as jest.Mock).mockResolvedValue([{ id: 'a1' }]);
+    (prisma.answer.findMany as jest.Mock).mockResolvedValue([
+      { id: 'a1', user: { name: 'User1' } },
+    ]);
     const res = await request(app).get('/school/doubts/d1/answers');
     expect(res.status).toBe(200);
-    expect(res.body).toEqual([{ id: 'a1' }]);
+    expect(res.body).toEqual([{ id: 'a1', user: { name: 'User1' } }]);
   });
 
   it('handles db error', async () => {


### PR DESCRIPTION
## Summary
- include user names when listing answers for a doubt
- update tests for the new answer structure

## Testing
- `npx jest` *(fails: 403 Forbidden to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68737615c42c8323b7b55f7e35ec8aaa