### PR TITLE
Allow parents to create leave requests for students

### DIFF
--- a/backend/src/validations/Module/SuperadminDashboard/leaveRequestValidation.ts
+++ b/backend/src/validations/Module/SuperadminDashboard/leaveRequestValidation.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 export const leaveRequestSchema = z.object({
+  userId: z.string().cuid().optional(),
   reason: z.string().min(1, "Reason is required"),
   fromDate: z.coerce.date({ invalid_type_error: "Invalid from date" }),
   toDate: z.coerce.date({ invalid_type_error: "Invalid to date" }),


### PR DESCRIPTION
## Summary
- allow optional userId when creating leave requests
- if a parent provides a child userId, validate it and create the leave for that child

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68738508d5fc8323a8c7282c37da71b7